### PR TITLE
Add examples to clarify Host and Regular expression URI match behavior

### DIFF
--- a/_articles/features/uri-match-detection.md
+++ b/_articles/features/uri-match-detection.md
@@ -75,8 +75,8 @@ The regular expression option allows you to write any simple or complex [regular
 
 Example:
 
-- URI regex value: `^https://.*google.com`
-- Matches: `https://google.com`, `https://sub.google.com`, `https://sub.sub2.google.com`, `https://malicious-site.com?q=google.com`, `https://google.com/search?q=term`
+- URI regex value: `^https://.*google.com$`
+- Matches: `https://google.com`, `https://sub.google.com`, `https://sub.sub2.google.com`, `https://malicious-site.com?q=google.com`
 - Not matches: `http://google.com` (not https), `https://yahoo.com`
 
 **Exact**

--- a/_articles/features/uri-match-detection.md
+++ b/_articles/features/uri-match-detection.md
@@ -52,7 +52,7 @@ Example:
 
 - URI host value: `https://sub.domain.com:4000`
 - Matches: `http://sub.domain.com:4000`, `http://sub.domain.com:4000/page.html`
-- Not matches: `https://domain.com`, `https://sub.domain.com`, `https://sub2.domain.com`, `https://sub.domain.com:5000`
+- Not matches: `https://domain.com`, `https://sub.domain.com`, `https://sub2.domain.com`, `https://sub.domain.com:5000`, `http://sub2.sub.domain.com:4000`
 
 **Starts with**
 
@@ -76,7 +76,7 @@ The regular expression option allows you to write any simple or complex [regular
 Example:
 
 - URI regex value: `^https://.*google.com`
-- Matches: `https://google.com`, `https://sub.google.com`, `https://sub.sub2.google.com`, `https://malicious-site.com?q=google.com`
+- Matches: `https://google.com`, `https://sub.google.com`, `https://sub.sub2.google.com`, `https://malicious-site.com?q=google.com`, `https://google.com/search?q=term`
 - Not matches: `http://google.com` (not https), `https://yahoo.com`
 
 **Exact**


### PR DESCRIPTION
* Add an example to the `Host` section illustrating that `Host` not only doesn't match parent domains but also doesn't match subdomains
* Add an example to `Regular expression` illustrating that the example regex matches substrings of the URI (because there is no end of string character)