### PR TITLE
Added note: auto-fill shortcut not working

### DIFF
--- a/_articles/features/auto-fill-browser.md
+++ b/_articles/features/auto-fill-browser.md
@@ -34,6 +34,8 @@ You can use a set of keyboard shortcuts (hot keys) to quickly auto-fill a login 
 - Linux: `Ctrl + Shift + L`
 - macOS: `Cmd + Shift + L`
   - Safari: `Cmd + \`
+  
+{% note %}If a shortcut does not work, it may be because another program is using it. The auto-fill shortcut is commonly claimed by the AMD Radeon Adrenaline software (AMD graphic drivers) and therefore can not be used by Bitwarden. You can free up this shortcut by changing it in the AMD Radeon software under Gaming > Global Settings > Performance Monitoring: "Toggle Performance Logging Hotkey".{% endnote %}
 
 Another option is to open the popup window using the keyboard shortcut (see below). You can then `TAB` to the login that you would like to auto-fill and then press `ENTER` to select.
 


### PR DESCRIPTION
I couldn't figure out why the auto-fill shortcut in Chrome was not working.  It was driving me absolutely insane.  I finally figured out that the AMD Radeon software was causing this. I thought I'd add this information so other people can find it more easily.