### PR TITLE
Fix broken links

### DIFF
--- a/_articles/importing/import-data.md
+++ b/_articles/importing/import-data.md
@@ -86,7 +86,7 @@ Social,1,login,Twitter,,,twitter.com,me@example.com,password123,
 ,,note,My Note,"This is a secure note.",,,,,
 ```
 
-[{% icon fa-download %} Download example](/files/bitwarden_export.csv)
+[{% icon fa-download %} Download example](/help/files/bitwarden_export.csv)
 
 When importing from this format, select the **Bitwarden (csv)** file format option from the dropdown menu.
 
@@ -108,7 +108,7 @@ collections,type,name,notes,fields,login_uri,login_username,login_password,login
 ,note,My Note,"This is a secure note.",,,,,
 ```
 
-[{% icon fa-download %} Download example](/files/bitwarden_export_org.csv)
+[{% icon fa-download %} Download example](/help/files/bitwarden_export_org.csv)
 
 When importing from this format, select the **Bitwarden (csv)** file format option from the dropdown menu.
 


### PR DESCRIPTION
After the change from help.bitwarden.com to bitwarden.com/help some link broke, these are two of them.