### PR TITLE
Added alternate hotkey for safari autofill cmd

### DIFF
--- a/_articles/features/auto-fill-browser.md
+++ b/_articles/features/auto-fill-browser.md
@@ -32,7 +32,7 @@ You can use a set of keyboard shortcuts (hot keys) to quickly auto-fill a login 
 - Windows: `Ctrl + Shift + L`
 - Linux: `Ctrl + Shift + L`
 - macOS: `Cmd + Shift + L`
-  - Safari: `Cmd + \` or `Cmd + 8`
+  - Safari: `Cmd + \` or `Cmd + 8` or `Cmd + Shift + P`
   
 {% note %}If a shortcut does not work, it may be because another application on your device is already using it. For example, the auto-fill shortcut on Windows is commonly claimed by the AMD Radeon Adrenaline software (AMD graphic drivers) and therefore cannot be used by Bitwarden. You can free up this shortcut by changing it in the AMD Radeon software under Gaming &rarr; Global Settings &rarr; Performance Monitoring: "Toggle Performance Logging Hotkey".{% endnote %}
 


### PR DESCRIPTION
## Overview
This relates to adding additional support for keyboards such as AZERTY, or QWERTY with a German layout, etc. where the existing hotkeys do not work due to additional key combinations that are already bound or simply not possible.

⌘8 does't work on all foreign keyboard layouts such as AZERTY, but supports some alternative keyboards
⌘\ also doesn't work on all keyboards
⇧⌘P, however, is not yet bound in Safari by default and does seem to work for all mentioned keyboards (so far).

Assuming this fix allows all possible keyboard combinations for macOS keyboards across regions with one of the 3 options since we can't control bindings themselves from an extension. In the future, we may be able to make this configurable through the Bitwarden extension settings itself (preferably).

_pending final commit from https://github.com/bitwarden/browser/issues/701_ (not to be merged until then).