### PR TITLE
typo in ga script

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -196,7 +196,7 @@
             crossorigin="anonymous" integrity="sha256-+nuEu243+6BveXk5N+Vbr268G+4FHjUOEcfKaBqfPbc= sha384-ugp/e34LtoER7mwf3SLygR0OL+STa4FTLzk7MRbpY/usE4VV+24hBxRXRS6g5ZJy sha512-JZSo0h5TONFYmyLMqp8k4oPhuo6yNk9mHM+FY50aBjpypfofqtEWsAgRDQm94ImLCzSaHeqNvYuD9382CEn2zw=="></script>
     <script src="{{site.baseurl}}/lib/fluidbox/js/jquery.fluidbox.min.js"></script>
     {% if jekyll.environment == "production" %}
-    <script src="{{site.baseurl}}/js/ga.min.js?v={{'now' | date: "%s"}}"></script>
+    <script src="{{site.baseurl}}/js/ga.js?v={{'now' | date: "%s"}}"></script>
     {% else %}
     <script src="{{site.baseurl}}/js/ga-noop.min.js"></script>
     {% endif %}


### PR DESCRIPTION
https://github.com/bitwarden/help/commit/981ef7c3c66a9143b239416d8e2112b3dd523ebc

back in May during some refactoring the filenames were incorrectly named or referenced. I went ahead and renamed the reference so that the Google Analytics for the help page will now be properly tracked in production once the pull request is approved.