### PR TITLE
Mention how the --raw option affects bw export

### DIFF
--- a/_articles/miscellaneous/cli.md
+++ b/_articles/miscellaneous/cli.md
@@ -333,7 +333,7 @@ bw import bitwardencsv ./file.csv
 
 ### Export
 
-The `export` command allows you to export your Vault data as plaintext `.json` or `.csv` files, or as a `.json` [Encrypted Export]({% link _articles/importing/encrypted-export.md %}).
+The `export` command allows you to export your Vault data as plaintext `.json` or `.csv` files, or as a `.json` [Encrypted Export]({% link _articles/importing/encrypted-export.md %}). You can pass the `--raw` option to receive your export on stdout instead of a file.
 
 Valid format values are `csv`, `json`, and `encrypted_json`.
 
@@ -342,6 +342,7 @@ bw export [password] [--output <filePath>] [--format <format>] [--organizationid
 ```
 ```
 bw export
+bw --raw export
 bw export --format csv
 bw export myPassword321 --output ./backups/
 bw export myPassword321 --output ./my_backup.json --format json


### PR DESCRIPTION
I had a hard time finding how to export my vault to stdout rather than a file on disk (see https://community.bitwarden.com/t/allow-exporting-to-vault-to-stdout/3772/3 ), so this is a tiny fix to mention that the `--raw` option makes `bw export` do this.