### PR TITLE
Expand docs about browser permission upgrade in v1.48.0

### DIFF
--- a/_articles/account/biometrics.md
+++ b/_articles/account/biometrics.md
@@ -63,9 +63,11 @@ Once Biometric Unlock is enabled, a new button will be presented on the Unlock s
 ## Browser Extensions
 
 {% callout warning %}
-Upon release of Biometric Unlock for Browser Extensions, you may notice that the Browser Extension is flagged by your browser for requiring a new permission. In some cases, browsers will disable the Browser Extension and users will be required to re-enable them.
+Version 1.48.0 of the browser extension enables Unlock with Biometrics, if you have at least version 2021-01-19 of the desktop app.
 
-The required permission to `nativeMessaging` is used to facilitate the integration between Browser Extension and Desktop Application that enabled Biometric Unlock, as described in this section.
+Note that when your browser updates to this version, you may be asked to accept a new permission called "communicate with cooperating native applications" (in Chromium-based browsers), or "exchange messages with programs other than Firefox." If you don't accept this permission, the extension will remain disabled.
+
+This permission, also known as `nativeMessaging`, is safe to accept and enables the browser extension to communicate with the Bitwarden desktop app, which is required to enabled Unlock with Biometrics, as described in this section.
 {% endcallout%}
 
 Biometric Unlock is supported for **Firefox** and **Chromium-based** (i.e. Chrome, Edge) Bitwarden Browser Extensions by integration with a native Bitwarden Desktop App. Through the Desktop App's access to Biometric APIs, Browser Extensions support Biometric Unlock:

--- a/_articles/faqs/security-faqs.md
+++ b/_articles/faqs/security-faqs.md
@@ -101,9 +101,12 @@ When this **optional feature** is enabled, clipboard clear will clear any Bitwar
 
 #### Q: Why does the Browser Extension need `nativeMessaging` permission?
 
-**A:** Upon the release of [Biometric Unlock for Browser Extensions](https://bitwarden.com/help/article/biometrics/#browser-extensions), you may notice that the Bitwarden Browser Extension is flagged by your browser for requiring a new permission. In some cases, browsers will disable the Browser Extension and users will be required to re-enable them.
+**A:**
+Version 1.48.0 of the browser extension enables [Biometric Unlock for Browser Extensions](https://bitwarden.com/help/article/biometrics/#browser-extensions).
 
-Bitwarden uses `nativeMessaging` permission to facilitate the integration between Browser Extension and Desktop Application that enables Biometric Unlock.
+This permission, also known as `nativeMessaging`, is safe to accept and allows the browser extension to communicate with the Bitwarden desktop app, which is required to enabled Unlock with Biometrics.
+
+Note that when your browser updates to this version, you may be asked to accept a new permission called "communicate with cooperating native applications" (in Chromium-based browsers), or "exchange messages with programs other than Firefox." If you don't accept this permission, the extension will remain disabled.
 
 #### Q: Is Bitwarden FIPS Compliant?
 

--- a/_articles/getting-started/releasenotes.md
+++ b/_articles/getting-started/releasenotes.md
@@ -22,7 +22,13 @@ Bitwarden believes source code transparency is an absolute requirement for secur
 ## Release Announcements
 
 {% callout info %}
-**Browser extensions are getting biometrics** in our 2021-01-19 release! New permission requests are normal (see [here](https://bitwarden.com/help/article/biometrics/#browser-extensions) for details).
+**Unlock with Biometrics now works in browser extensions.**
+
+This is available from v1.48.0 of the browser extension, if you have at least version 2021-01-19 of the desktop app.
+
+Note that when your browser updates to this version, you may be asked to accept a new permission called "communicate with cooperating native applications," or "exchange messages with programs other than Firefox." This permission is safe to accept, and enables the browser extension to communicate with the Bitwarden desktop app, which is required to enabled Unlock with Biometrics.
+
+See the [documentation](https://bitwarden.com/help/article/biometrics/#browser-extensions) for more details on how to enable this feature.
 {% endcallout %}
 
 {% callout info %}


### PR DESCRIPTION
By including the text of the browser `nativeMessaging` permission dialog, users can Google the message they see in the somewhat scary looking browser permissions dialog, and land here on the official documentation.

I also included the actual versions of the extension/app required to make the docs a little clearer.

See also https://github.com/bitwarden/browser/issues/1548.

For reference, this is what the browser permission dialog looks like (in Chrome):
![image](https://user-images.githubusercontent.com/138615/105633398-9da68100-5e58-11eb-8f51-1d5375248000.png)

And for Firefox, from [Reddit](https://www.reddit.com/r/Bitwarden/comments/l31sj9/whats_this_about/):
![image](https://user-images.githubusercontent.com/138615/105633426-c169c700-5e58-11eb-9052-2b72605ee97f.png)
