### PR TITLE
Add instructions for building the site with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,23 @@ Run the following commands:
 - `npm install`
 - `npm run build:watch`
 
-You can now access the help center at `http://localhost:4009`.
+You can now access the help center at `http://localhost:4009`. As soon as you save any changes, Jekyll will compile them and automatically reload the page in your browser.
+
+## Docker
+
+Alternatively, you can build and test the site without installing Node.js, Ruby etc. on your machine.
+
+Assuming you have Docker installed, you can run this setup command:
+```
+docker run --rm -t -i -v $(PWD):/srv/jekyll jekyll/jekyll:4 npm install
+```
+
+Then run this command to build and serve the site:
+```
+docker run --rm -t -i -v $(PWD):/srv/jekyll \
+  -p 4009:4009 -p 35729:35729 jekyll/jekyll:4 \
+  npm run build:watch
+```
 
 # Ruby Gems
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "bitwarden-help",
   "version": "0.0.0",
   "scripts": {
-    "build": "gulp build && jekyll build",
-    "build:watch": "gulp build && jekyll serve --watch --host=0.0.0.0",
+    "build": "gulp build && jekyll build --incremental",
+    "build:watch": "gulp build && jekyll serve --incremental --watch --livereload",
     "build:prod": "gulp build && cross-env JEKYLL_ENV=production jekyll build",
     "build:prod:sub": "gulp build && cross-env JEKYLL_ENV=production jekyll build --config _config.yml,_config-sub.yml"
   },


### PR DESCRIPTION
Building the site requires having appropriate versions of both Node.js and Ruby installed, which can be a pain.

I was able to easily work on the site using Docker, so I added some instructions, and made the dev workflow a little bit nicer with support for incremental building and live-reloading.