### PR TITLE
Fix URI vault regex example

### DIFF
--- a/_articles/features/uri-match-detection.md
+++ b/_articles/features/uri-match-detection.md
@@ -75,7 +75,7 @@ Regular expressions are an advanced option and can be quite dangerous if used in
 
 Selecting **Regular expression** will prompt Bitwarden to offer auto-fill when the detected resources matches a specified [regular expression](https://en.wikipedia.org/wiki/Regular_expression){:target="_blank"}. Regular expressions are always *case insensitive*.
 
-For example, if the URI vault `^https://.*google.com$` uses regular expression match detection:
+For example, if the URI vault `^https://.*google\.com$` uses regular expression match detection:
 
 - **Auto-fill offered** for `https://google.com`, `https://sub.google.com`, `https://malicious-site.com?q=google.com`
 - **Auto-fill not offered** for `http://google.com` or `https://yahoo.com`


### PR DESCRIPTION
I find it important that examples actually follow best practices. The current regex does not escaping dots in URIs when writing regex is a mistake that is often made, even by advanced regex people. I think this comes from the way we humans look at URIs. Dots are so common in there, aren’t they?  Yes, but we write proper regular expressions here, not something in between.

**Note: This is just a quick fix, please consider #158 (additionally)**

Fixes: #392
Updates: #41
Full fix: #158
Replaces: #160
