### PR TITLE
Removes custom Safari shortcut docs

### DIFF
--- a/_articles/features/auto-fill-browser.md
+++ b/_articles/features/auto-fill-browser.md
@@ -42,7 +42,6 @@ To auto-fill login information, use the following **default** shortcuts:
 - On Windows: `Ctrl + Shift + L`
 - On macOS: `Cmd + Shift + L`
 - On Linux: `Ctrl + Shift + L`
-- Safari: `Cmd + \` or `Cmd + 8` or `Cmd + Shift + P`
 
 {% callout success %}
 If a login uses the [Bitwarden Authenticator]({% link _articles/features/authenticator-keys.md %}) for TOTPs, using the `Cmd/Ctrl + Shift + L` will automatically copy your TOTP to your clipboard after auto-filling. All you have to do is `Cmd/Ctrl + V` to paste!


### PR DESCRIPTION
Bitwarden 1.25.0 on MacOS with Safari seems to use the standard MacOS shortcut for autofill (`Cmd + Shift + L`) and the custom Safari shortcuts no longer work (`Cmd + \ or Cmd + 8 or Cmd + Shift + P`).

Assuming this is new behavior is not a bug, this PR removes the old shortcuts from the help doc.