### PR TITLE
Pin versions of actions in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '10.x'
+          node-version: '14'
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: actions/setup-ruby@e932e7af67fc4a8fc77bd86b744acd4e42fe3543
         with:
           ruby-version: 2.6
 
@@ -27,7 +27,7 @@ jobs:
           jekyll --version
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Install Node dependencies
         run: npm install
@@ -42,7 +42,7 @@ jobs:
 
       - name: Deploy to S3
         if: github.ref == 'refs/heads/master'
-        uses: jakejarvis/s3-sync-action@master
+        uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
@@ -55,7 +55,7 @@ jobs:
 
       - name: Deploy to staging
         if: github.ref == 'refs/heads/staging'
-        uses: SamKirkland/FTP-Deploy-Action@2.0.0
+        uses: SamKirkland/FTP-Deploy-Action@9c4e4646b8b71d9ff86cfb1a44395ce36bf5ae56
         env:
           FTP_SERVER: ${{ secrets.STAGING_FTP_SERVER }}
           FTP_USERNAME: ftpuser


### PR DESCRIPTION
This pins all action versions in the workflows to commit hashes. This protects us from any malicious changes to the actions in case people force push tags.