### PR TITLE
Correct typo in LDAP directory sync article

### DIFF
--- a/_articles/directory-connector/ldap-directory.md
+++ b/_articles/directory-connector/ldap-directory.md
@@ -118,7 +118,7 @@ To filter a sync for all entries that have `objectClass=user` and `cn` (common n
 
 ## Test a Sync
 
-To test whether Directory Connector will successfully connect to your Directory and return the desired users and groups, navigate to teh **Dashbaord** tab and select the **Test Now** button. If successful, users and groups will be printed to the Directory Connector window according the specified [Sync Options](#configure-sync-options) and [Filters](#specify-sync-filters):
+To test whether Directory Connector will successfully connect to your Directory and return the desired users and groups, navigate to the **Dashboard** tab and select the **Test Now** button. If successful, users and groups will be printed to the Directory Connector window according the specified [Sync Options](#configure-sync-options) and [Filters](#specify-sync-filters):
 
 {% image /directory-connector/okta/dc-okta-test.png Test sync results %}
 


### PR DESCRIPTION
**Purpose of this PR**
I noticed two easy-to-fix typos in the `Test a Sync` portion of the Sync with Active Directory or LDAP help site article. This PR corrects them. 

**Article in question** 
https://bitwarden.com/help/article/ldap-directory/#test-a-sync

**Other info**
I wasn't able to get the project to build locally to provide a screenshot of the fix, but I think this change is pretty low-risk. So, humbly submitting for your review. Thanks!

