### PR TITLE
Remove double word typo

### DIFF
--- a/_articles/organizations/share-to-a-collection.md
+++ b/_articles/organizations/share-to-a-collection.md
@@ -13,7 +13,7 @@ order: 04
 In order to share items you need to be a member of an Organization. Learn more about [Organizations]({% link _articles/organizations/about-organizations.md %}) or learn how to [start your own two-person Organization]({{site.baseurl}}/article/getting-started-organizations/).
 {% endcallout %}
 
-Sharing items with Bitwarden means putting them into a Collection, a structure used to gather together together Logins, Notes, Cards, and Identities for access by multiple users. There are a few different ways you can share an item to a Collection:
+Sharing items with Bitwarden means putting them into a Collection, a structure used to gather together Logins, Notes, Cards, and Identities for access by multiple users. There are a few different ways you can share an item to a Collection:
 
 ## Share an Existing Item
 
@@ -27,9 +27,9 @@ Organization members can share items to any assigned Collection(s) unless they'r
 3. On the **Share** screen:
 
    - Choose the **Organization** to share this item with.
-   - Select one or more **Collections** to share this item into. You must select *at least* one Collection.
+   - Select one or more **Collections** to share this item into. You must select _at least_ one Collection.
 
-5. Click **Save** to finishing sharing this item.
+4. Click **Save** to finishing sharing this item.
 
 Sharing an item **will transfer ownership to the Organization**. This means that anyone with permission can alter the item or delete it, which would remove it from your Vault as well. You can tell that an item is shared when it has the {% icon fa-share-alt %} **Shared** icon next to its name:
 
@@ -58,7 +58,7 @@ To create a new shared item:
 1. On the {% icon fa-lock %} **My Vault** page, select the {% icon fa-plus %} **Add Item** button.
 2. Fill in all the relevant information for the new Vault item.
 3. In the **Ownership** section at the bottom of the Add Item panel, choose the Organization you want to share this item with.
-4. Select one or more **Collections** to share this item into. You must select *at least* one Collection.
+4. Select one or more **Collections** to share this item into. You must select _at least_ one Collection.
 5. Select the **Save** button to finishing creating the shared item.
 
 Creating a shared item **will set ownership to the Organization**. This means that anyone with permission can alter the item or delete it, which would remove it from your Vault as well. You can tell that an item is shared when it has the {% icon fa-share-alt %} **Shared** icon next to its name:
@@ -67,6 +67,7 @@ Creating a shared item **will set ownership to the Organization**. This means th
 
 {% endcapture %}
 {{ personal | markdownify }}
+
   </div>
   <div class="tab-pane" id="organization" role="tabpanel" aria-labelledby="orgtab">
 {% capture organization %}
@@ -77,7 +78,7 @@ To create a new shared item:
 
 1. On your Organization's {% icon fa-lock %} **Vault** tab, select the {% icon fa-plus %} **Add Item** button.
 2. Fill in all the relevant information for the new Vault item.
-3. The Ownership of the item is automatically set to the Organization when you use this method, so all you need to do is select one or more **Collections** to share this item into. You must select *at least* one Collection.
+3. The Ownership of the item is automatically set to the Organization when you use this method, so all you need to do is select one or more **Collections** to share this item into. You must select _at least_ one Collection.
 4. Select the **Save** button to finishing creating the shared item.
 
 Creating a shared item or sharing an item **will set ownership to the Organization**. This means that anyone with permission can alter the item or delete it, which would remove it from your Vault as well. You can tell that an item is shared when it has the {% icon fa-share-alt %} **Shared** icon next to its name:
@@ -86,5 +87,6 @@ Creating a shared item or sharing an item **will set ownership to the Organizati
 
 {% endcapture %}
 {{ organization | markdownify }}
+
   </div>
 </div>


### PR DESCRIPTION
The word `together` appears twice in a row on the [Organizations->Sharing](https://bitwarden.com/help/article/share-to-a-collection/) page.