### PR TITLE
Remove redundant cert reference

### DIFF
--- a/_articles/hosting/install-on-premise-manual.md
+++ b/_articles/hosting/install-on-premise-manual.md
@@ -52,7 +52,7 @@ Complete the following steps to install Bitwarden manually:
 
    ```
    openssl pkcs12 -export -out ./identity/identity.pfx -inkey identity.key \
-         -in identity.crt -certfile identity.crt -passout pass:IDENTITY_CERT_PASSWORD
+         -in identity.crt -passout pass:IDENTITY_CERT_PASSWORD
    ```
 5. Edit the `globalSettings__identityServer__certificatePassword` value in `./env/global.override.env` with your configured password.
 6. Copy the created files to the `./bwdata/ssl` directory.


### PR DESCRIPTION
- Match identity server certificate generation instructions in documentation to server changes: https://github.com/bitwarden/server/pull/1451
- Fixes "Unhandled exception. System.Security.Cryptography.CryptographicException: The certificate data cannot be read with the provided password, the password may be incorrect." error in identity server startup