### PR TITLE
Remove duplicate cert file openssl param

### DIFF
--- a/_articles/hosting/install-on-premise-manual.md
+++ b/_articles/hosting/install-on-premise-manual.md
@@ -52,7 +52,7 @@ Complete the following steps to install Bitwarden manually:
 
    ```
    openssl pkcs12 -export -out ./identity/identity.pfx -inkey identity.key \
-         -in identity.crt -certfile identity.crt -passout pass:IDENTITY_CERT_PASSWORD
+         -in identity.crt -passout pass:IDENTITY_CERT_PASSWORD
    ```
 5. Edit the `globalSettings__identityServer__certificatePassword` value in `./env/global.override.env` with your configured password.
 6. Copy the created files to the `./bwdata/ssl` directory.


### PR DESCRIPTION
see: https://github.com/bitwarden/server/issues/1528

Needed to update the self-hosting manual configuration docs to remove the `--certfile` argument after the .net 5.0 upgrade which doesn't support duplicate certificates.