### PR TITLE
Misc 09 13

### DIFF
--- a/_articles/directory-connector/schedule-directory-sync.md
+++ b/_articles/directory-connector/schedule-directory-sync.md
@@ -22,8 +22,9 @@ In order to continue, you will also need your Organization's [API Key]({{site.ba
 
 ### Setup a Sync Script
 
-In order avoid session timeouts, we recommend creating a shell script to run through cron, for example:
+In order avoid session timeouts, we recommend creating a shell script to run through cron. This script should securely read your `client_secret` to complete the login, and run a `bwdc sync` command that writes output to `bwdc.log`. If you need help creating a sync script, [Contact Us](https://bitwarden.com/contact).
 
+{% comment %}
 ```
 #!/bin/bash
 
@@ -39,8 +40,7 @@ bwdc login
 ​
 bwdc sync >> bwdc.log
 ```
-
-This script will securely read your `client_secret` to complete the login, and run a `bwdc sync` command that writes output to `bwdc.log`.
+{% endcomment %}
 
 ### Setup the Cron Job
 

--- a/_articles/hosting/environment-variables.md
+++ b/_articles/hosting/environment-variables.md
@@ -51,3 +51,4 @@ The following variables do not already exist in `global.override.env`, and can b
 |globalSettings__mail__smtp__startTls=|Specify `true` to force STARTTLS (Opportunistic TLS).|
 |globalSettings__organizationInviteExpirationHours=|Specify the number of hours after which an Organization Invite will expire (`120` by default).|
 |globalSettings__yubico__validationUrls__0=|Primary URL for self-hosted Yubico Validation Server. For example: `=https://your.url.com/wsapi/2.0/verify`.<br><br>Add additional Validation Server URLs by creating incremented environment variables, for example `globalSettings__yubico__validationUrls__1=`, `globalSettings__yubico__validationUrls__2=`.|
+|adminSettings__deleteTrashDaysAgo=|Specify the number of days after which to permanently delete items from the Trash. By default, `adminSettings__deleteTrashDaysAgo=30`.|

--- a/_articles/login-with-sso/oidc-azure.md
+++ b/_articles/login-with-sso/oidc-azure.md
@@ -61,7 +61,7 @@ At this point, you've configured everything you need within the context of the A
 |-----|-----------|
 |Authority|Enter `https://login.microsoft.com/<TENANT_ID>/v2.0`, where `TENANT_ID` is the **Directory (tenant) ID** value retrieved from the App registration's Overview screen.|
 |Client ID|Enter the App registration's **Application (client) ID**, which can be retrieved from the Overview screen.|
-|Client Secret|Enter the **Secret ID** of the [created Client Secret](#create-a-client-secret).|
+|Client Secret|Enter the **Secret Value** of the [created Client Secret](#create-a-client-secret).|
 |Metadata Address|For Azure implementations as documented, you can leave this field blank.|
 |OIDC Redirect Behavior|Select either **Form POST** or **Redirect GET**.|
 |Get Claims From User Info Endpoint|Enable this option if you receive URL too long errors (HTTP 414), truncated URLS, and/or failures during SSO.|

--- a/_articles/send/send-cli.md
+++ b/_articles/send/send-cli.md
@@ -64,23 +64,74 @@ A typical workflow might look something like:
 3. Use the `encode` command (see [details]({{site.baseurl}}/article/cli/#encode)) to encode the manipulated JSON.
 4. Use the `create` command to create a Send from the encoded JSON.
 
-For example:
+For example, to create a text Send:
 
 ```
 bw send template send.text | jq '.name="My First Send" | .text.text="Secrets I want to share."' | bw encode | bw send create
 ```
 
+For example, to create a password-protected file Send:
+
 ```
 bw send template send.file | jq '.name="My File Send" | .type=1 | .file.fileName="paperwork.png" | .password="p@ssw0rd"' | bw encode | bw send create
 ```
+
+For example, to create a password-protected file Send with an explicit [deletion date]({{site.baseurl}}/article/send-lifespan/#deletion-date). This example is broken out by operating system due to the way `.deletionDate=` should be specified:
+
+<ul class="nav nav-tabs" id="myTab" role="tablist">
+  <li class="nav-item" role="presentation">
+    <a class="nav-link active" id="wintab" data-bs-toggle="tab" data-target="#windows" role="tab" aria-controls="windows" aria-selected="true"><i class="fa fa-windows"></i> Windows</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="mactab" data-bs-toggle="tab" data-target="#macos" role="tab" aria-controls="macos" aria-selected="false"><i class="fa fa-apple"></i> macOS</a>
+  </li>
+  <li class="nav-item" role="presentation">
+    <a class="nav-link" id="lintab" data-bs-toggle="tab" data-target="#linux" role="tab" aria-controls="linux" aria-selected="false"><i class="fa fa-linux"></i> Linux</a>
+  </li>
+</ul>
+<div class="tab-content" id="clientsContent">
+  <div class="tab-pane show active" id="windows" role="tabpanel" aria-labelledby="wintab">
+{% capture winfo %}
+#### Windows
+
+```
+$delDate = (Get-Date).AddDays(14) | date -UFormat "%Y-%m-%dT%H:%M:%SZ"
+
+bw send template send.text | jq ".name=\`"My Send\`" | .text.text=\`"Secrets I want to share.\`" | .password=\`"password\`" | .deletionDate=\`"$delDate\`"" | bw encode | bw send create
+```
+
+Notice in this example that the jq invocation must be wrapped in double quotes (`" "`) and use escapes (`\`) for each filter due to a nested `date` variable that configures a `.deletionDate` in the Send.
+
+{% endcapture %}
+{{ winfo | markdownify }}
+  </div>
+  <div class="tab-pane" id="macos" role="tabpanel" aria-labelledby="mactab">
+{% capture minfo %}
+#### macOS
 
 ```
 bw send template send.text | jq ".name=\"My Send\" | .text.text=\"Secrets I want to share.\" | .password=\"mypassword\" | .deletionDate=\"$(date -uv+14d + "%Y-%m-%dT%H:%M:%SZ")\"" | bw encode | bw send create
 ```
 
-{% callout success %}
-Notice in the final example that the jq invocation must be wrapped in double quotes (`" "`) and use escapes (`\`) for each filter due to a nested `date` variable that configures a `.deletionDate` in the Send.
-{% endcallout %}
+Notice in this example that the jq invocation must be wrapped in double quotes (`" "`) and use escapes (`\`) for each filter due to a nested `date` variable that configures a `.deletionDate` in the Send.
+
+{% endcapture %}
+{{ minfo | markdownify }}
+  </div>
+  <div class="tab-pane" id="linux" role="tabpanel" aria-labelledby="lintab">
+{% capture linfo %}
+#### Linux
+
+```
+bw send template send.text | jq ".name=\"My Send\" | .text.text=\"Secrets I want to share.\" | .password=\"mypassword\" | .deletionDate=\"$(date "+%Y-%m-%dT%H:%M:%SZ" -d "+14 days")\"" | bw encode | bw send create
+```
+
+Notice in this example that the jq invocation must be wrapped in double quotes (`" "`) and use escapes (`\`) for each filter due to a nested `date` variable that configures a `.deletionDate` in the Send.
+
+{% endcapture %}
+{{ linfo | markdownify }}
+  </div>
+</div>
 
 **Options:**
 


### PR DESCRIPTION
This PR:
- Fix to Client Secret value in Azure OIDC Implementation Guide.
- Breaks out `create` Send examples with `.deletionDate` specified by OS.
- Removes a script example from Scheduling Directory Syncs (per @sevensixseven).
- Adds `adminSettings__deleteTrashDaysAgo=` option to environment variables list.