### PR TITLE
Enterprise policies: update cannot be confirmed -> cannot accept invite

### DIFF
--- a/_articles/organizations/policies.md
+++ b/_articles/organizations/policies.md
@@ -81,7 +81,7 @@ Enabling the **Single Organization** policy will restrict non-Owner/non-Admin me
 {% callout warning %}
 **Users in the Organization who are members of multiple Organizations will be removed from the Organization when you enable this policy.**
 
-Users who are removed as a result of this policy will be notified via email, and must be re-invited to the Organization. Users will not be able to be confirmed to the Organization until they have removed themselves from all other Organizations.
+Users who are removed as a result of this policy will be notified via email, and must be re-invited to the Organization. Users will not be able to be accept the invitation to the Organization until they have removed themselves from all other Organizations.
 {% endcallout %}
 
 ### Single Sign-On Authentication


### PR DESCRIPTION
As per server implementation, these checks are done at invite acceptance and confirmation rather than just confirmation.

https://github.com/bitwarden/server/blob/dac3b3e8939504959d94c2e2fd13789723ab2d57/src/Core/Services/Implementations/OrganizationService.cs#L1335-L1359

Given the checks treat people who have accepted an invitation as having accepted the policy implications, being blocked at confirmation time should realistically never happen. The one exception may be for maybe invitations accepted on an old version of bitwarden and but not yet confirmed.