### PR TITLE
add missing referrer to links

### DIFF
--- a/_includes/connect.html
+++ b/_includes/connect.html
@@ -2,8 +2,8 @@
     <h4 class="card-header"><i class="fa fa-bullhorn"></i> Connect with Us</h4>
     <div class="card-body">
         <p class="card-text"><i class="fa fa-shield"></i> <a href="https://community.bitwarden.com/" target="_blank">Forums</a></p>
-        <p class="card-text"><i class="fa fa-calendar"></i> <a href="https://www.crowdcast.io/bitwarden" target="_blank">Events</a></p>
-        <p class="card-text"><i class="fa fa-reddit"></i> <a href="https://reddit.com/r/bitwarden" target="_blank">Reddit</a></p>
-        <p class="card-text"><i class="fa fa-twitter"></i> <a href="https://twitter.com/Bitwarden" target="_blank">Twitter</a></p>
+        <p class="card-text"><i class="fa fa-calendar"></i> <a href="https://www.crowdcast.io/bitwarden" target="_blank" rel="noreferrer">Events</a></p>
+        <p class="card-text"><i class="fa fa-reddit"></i> <a href="https://reddit.com/r/bitwarden" target="_blank" rel="noreferrer">Reddit</a></p>
+        <p class="card-text"><i class="fa fa-twitter"></i> <a href="https://twitter.com/Bitwarden" target="_blank" rel="noreferrer">Twitter</a></p>
     </div>
 </div>

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -3,7 +3,7 @@
     <div class="card-body">
         <p class="card-text"><i class="fa fa-download"></i> <a href="https://bitwarden.com/download" target="_blank">Download Bitwarden</a></p>
         <p class="card-text"><i class="fa fa-wrench"></i><a href="https://community.bitwarden.com/t/about-the-feature-requests-category" target="_blank"> Make a Feature Request</a></p>
-        <p class="card-text"><i class="fa fa-edit"></i> <a href="https://github.com/bitwarden/help/issues/new?assignees=&labels=&template=help-center-edit-suggestion.md&title=" target="_blank">Suggest an Edit</a></p>
+        <p class="card-text"><i class="fa fa-edit"></i> <a href="https://github.com/bitwarden/help/issues/new?assignees=&labels=&template=help-center-edit-suggestion.md&title=" target="_blank" rel="noreferrer">Suggest an Edit</a></p>
         <p class="card-text"><i class="fa fa-comments"></i> <a href="https://community.bitwarden.com/c/support/" target="_blank">Ask the Community</a></p>
         <p class="card-text"><i class="fa fa-envelope"></i> <a href="https://bitwarden.com/contact" target="_blank">Contact Us</a></p>
     </div>


### PR DESCRIPTION
Adds missing noreferrer to external resources for safety.

This change only targets external links and not bitwarden.com (i can change this)
Non-breaking, codebase already uses rel="noreferrer"

requesting hacktoberfest-accepted label.
I use & like Bitwarden.